### PR TITLE
Restructure printable auction catalogue

### DIFF
--- a/layouts/auction/printable-catalogue.html
+++ b/layouts/auction/printable-catalogue.html
@@ -4,53 +4,59 @@
   {{ partial "head.html" . }}
 
   <body>
-    <div id="all">
-    {{ $auctionConfig := .Site.Data.AuctionConfig }}
-    {{ if (fileExists "content/auction/auctionItems.csv") }}
-      {{ range .Site.Menus.auction }}
-        {{ $category := .Name }}
-        <h1>{{ $category }}</h1>
-        <table id="auction-items-table" class="table table-striped table-bordered" style="width:100%">
-          <thead>
-            <tr>
-              <th scope="col">Picture</th>
-              <th scope="col">Description</th>
-              <th scope="col">Status</th>
-              <th scope="col">ID</th>
-            </tr>
-          </thead>
-          <tbody>
-              {{ $data := getCSV "," "content/auction/auctionItems.csv"}}
-              {{ range after 1 $data }}
-                {{ if (in $category (index . 3)) }}
-                  <tr>
+    <div class="printable-catalogue">
+      {{ $auctionConfig := .Site.Data.AuctionConfig }}
+      {{ if (fileExists "content/auction/auctionItems.csv") }}
+
+        {{ $node := . }}
+
+        {{ range .Site.Menus.auction }}
+          {{ $category := .Name }}
+          {{ $category := .Name }}
+          <h1>{{ $category }}</h1>
+          <div class="printable-catalogue-table">
+            <table>
+              <tbody>
+                {{ $data := getCSV "," "content/auction/auctionItems.csv"}}
+                {{ $node.Scratch.Set "i" 1 }}
+                <tr>
+                {{  range $item := after 1 $data }}
+                  {{ if (in $category (index $item 3)) }}
+                    {{ if eq (mod ($node.Scratch.Get "i") 6) 0 }}
+                      <tr>
+                    {{ end }}
                     <td>
-                      {{ $image := resources.Get (printf "/auction/images/%s.jpg" (index . 5)) }}
-                      {{ if $image }}
-                        {{ $thumbnail := $image.Fill "180x180" }}
-                        <img class="auction-item-thumbnail" src={{$thumbnail.Permalink}}>
+                      <div class="printable-catalogue-item">
+                        <div class="printable-catalogue-image">
+                          {{ $image := resources.Get (printf "/auction/images/%s.jpg" (index . 5)) }}
+                          {{ if $image }}
+                            {{ $thumbnail := $image.Fill "180x180" }}
+                            <img class="auction-item-thumbnail" src={{$thumbnail.Permalink}}>
+                          {{ end }}
+                        </div>
+                        <div class="printable-catalogue-text">
+                          <b>{{ index $item 0 }}</b><br>
+                          {{ index $item 1 }}<br>
+                          Status: {{ index $item 2 }}<br>
+                          ID: {{ index $item 5 }}
+                        </div>
+                      </div>
+                    <td>
+                      {{ $node.Scratch.Add "i" 1 }}
+                      {{ if eq (mod ($node.Scratch.Get "i") 6) 0 }}
+                        </tr>
+                        {{ $node.Scratch.Set "i" 1 }}
                       {{ end }}
-                    </td>
-                    <td>
-                      <b>{{ index . 0 }}</b><br>
-                      {{ index . 1 }}
-                    </td>
-                    <td>
-                      {{ index . 2 }}
-                    </td>
-                    <td>
-                      {{ index . 5 }}
-                    </td>
-                  </tr>
+                  {{ end }}
                 {{ end }}
-              {{ end }}
-          </tbody>
-        </table>
+              </tbody>
+            </table>
+          </div>
+        {{ end }}
       {{ end }}
-    {{ end }}
-</div>
+    </div>
 
-{{ partial "scripts.html" . }}
+  {{ partial "scripts.html" . }}
 
-</body>
+  </body>
 </html>

--- a/layouts/auction/printable-catalogue.html
+++ b/layouts/auction/printable-catalogue.html
@@ -5,23 +5,37 @@
 
   <body>
     <div class="printable-catalogue">
+      <!-- Get the auction configuration files -->
       {{ $auctionConfig := .Site.Data.AuctionConfig }}
+      <!-- Check if the csv catalogue exists -->
       {{ if (fileExists "content/auction/auctionItems.csv") }}
 
+        <!-- Save the current "context" - in variable node. Requiered to use Scratch variables in ranges -->
         {{ $node := . }}
 
+        <!-- Go through all the auction categories, get these from the auction menu -->
         {{ range .Site.Menus.auction }}
           {{ $category := .Name }}
-          {{ $category := .Name }}
+
+          <!-- Put each category in each own section -->
           <h1>{{ $category }}</h1>
           <div class="printable-catalogue-table">
+            <!-- Create a table listing all the items in the current category -->
             <table>
               <tbody>
+                <!-- Parse the csv auction catalogue and save as variable data -->
                 {{ $data := getCSV "," "content/auction/auctionItems.csv"}}
+
+                <!-- Create an index variable to count the number of items pn each row in the table -->
                 {{ $node.Scratch.Set "i" 1 }}
                 <tr>
+                <!-- Range through all the items in the database and only select the ones matching the current category. -->
+                <!-- Skip first row containing the description of each field in the csv file -->
                 {{  range $item := after 1 $data }}
+                  <!-- Check if the category matches -->
                   {{ if (in $category (index $item 3)) }}
+
+                    <!-- Check if the table should create a new row -->
                     {{ if eq (mod ($node.Scratch.Get "i") 6) 0 }}
                       <tr>
                     {{ end }}
@@ -42,7 +56,10 @@
                         </div>
                       </div>
                     <td>
+                      <!-- Increment the index variable i -->
                       {{ $node.Scratch.Add "i" 1 }}
+
+                      <!-- Check if the table should create a new row -->
                       {{ if eq (mod ($node.Scratch.Get "i") 6) 0 }}
                         </tr>
                         {{ $node.Scratch.Set "i" 1 }}

--- a/themes/hugo-universal-theme/static/css/custom.css
+++ b/themes/hugo-universal-theme/static/css/custom.css
@@ -159,3 +159,31 @@ img.feature-image {
   right: 0;
   padding: 1em;
 }
+
+.printable-catalogue {
+  width: 210mm;
+  padding: auto;
+  padding: 5mm;
+  vertical-align: top;
+
+}
+
+.printable-catalogue-table table {
+  width: 100%;
+  table-layout: fixed;
+}
+
+.printable-catalogue-table td, th {
+  vertical-align:top;
+}
+
+.printable-catalogue-item {
+  width: 40mm;
+  padding: 2.5mm;
+  overflow-wrap: break-word;
+}
+
+.printable-catalogue-image img {
+  width: 100%;
+  height: auto;
+}


### PR DESCRIPTION
Make the printable auction catalogue more condensed by showing 4 items
on each table row.